### PR TITLE
feat: add typescript types, utils and API layer skeleton

### DIFF
--- a/frontend/src/api/neighborhoods.ts
+++ b/frontend/src/api/neighborhoods.ts
@@ -1,0 +1,27 @@
+import type { Neighborhood, NeighborhoodsResponse, SearchResponse } from '../types';
+
+const API_BASE = import.meta.env.VITE_API_URL || '';
+
+async function fetchOrMock<T>(path: string, mock: T): Promise<T> {
+  if (!API_BASE) return mock;
+  try {
+    const res = await fetch(`${API_BASE}${path}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json() as Promise<T>;
+  } catch (err) {
+    console.warn('[Livabl API] falling back to mock data:', err);
+    return mock;
+  }
+}
+
+export async function getNeighborhoods(): Promise<NeighborhoodsResponse> {
+  return fetchOrMock('/api/neighborhoods', { neighborhoods: [], total: 0 });
+}
+
+export async function searchNeighborhoods(query: string): Promise<SearchResponse> {
+  return fetchOrMock(`/api/search?q=${encodeURIComponent(query)}`, { query, results: [] });
+}
+
+export async function getNeighborhood(id: string): Promise<Neighborhood | null> {
+  return fetchOrMock(`/api/neighborhoods/${id}`, null);
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,44 @@
+export interface ScoreBreakdown {
+  safety: number;
+  walkability: number;
+  transit: number;
+  schools: number;
+  greenery: number;
+  noise: number;
+}
+
+export interface Neighborhood {
+  id: string;
+  name: string;
+  city: string;
+  region: string;
+  area_km2: number;
+  score: number;
+  breakdown: ScoreBreakdown;
+  coordinates: {
+    lat: number;
+    lng: number;
+  };
+  zone?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    pinX: number;
+    pinY: number;
+  };
+}
+
+export type ScoreCategory = 'all' | 'safety' | 'walkability' | 'transit' | 'schools' | 'greenery' | 'noise';
+export type MapLayer = 'livability' | 'safety' | 'transit';
+export type ScoreGrade = 'excellent' | 'average' | 'poor';
+
+export interface NeighborhoodsResponse {
+  neighborhoods: Neighborhood[];
+  total: number;
+}
+
+export interface SearchResponse {
+  query: string;
+  results: Neighborhood[];
+}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,37 @@
+import type { ScoreGrade } from './types';
+
+export function getGrade(score: number): ScoreGrade {
+  if (score >= 75) return 'excellent';
+  if (score >= 55) return 'average';
+  return 'poor';
+}
+
+export function getScoreColor(score: number): string {
+  if (score >= 75) return '#16a34a';
+  if (score >= 55) return '#d97706';
+  return '#dc2626';
+}
+
+export function getZoneFill(score: number, opacity = 0.15): string {
+  const color = getScoreColor(score);
+  const r = parseInt(color.slice(1, 3), 16);
+  const g = parseInt(color.slice(3, 5), 16);
+  const b = parseInt(color.slice(5, 7), 16);
+  return `rgba(${r},${g},${b},${opacity})`;
+}
+
+export function getBadgeStyle(score: number): { background: string; color: string } {
+  if (score >= 75) return { background: '#f0fdf4', color: '#16a34a' };
+  if (score >= 55) return { background: '#fffbeb', color: '#d97706' };
+  return { background: '#fef2f2', color: '#dc2626' };
+}
+
+export function getBarColor(value: number): string {
+  if (value >= 75) return '#4ade80';
+  if (value >= 55) return '#fbbf24';
+  return '#f87171';
+}
+
+export function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}


### PR DESCRIPTION
Sets up the foundational layer for the frontend:

- `src/types/index.ts` — defines data shapes for Neighborhood, ScoreBreakdown, API responses
- `src/utils.ts` — helper functions for score colors, grades, and badge styles
- `src/api/neighborhoods.ts` — API layer that calls the backend, with a mock fallback for offline development